### PR TITLE
Update disqus.html

### DIFF
--- a/docs/material/partials/integrations/disqus.html
+++ b/docs/material/partials/integrations/disqus.html
@@ -1,19 +1,15 @@
-{% set disqus = config.extra.disqus %}
-{% if page and page.meta and page.meta.disqus is string %}
-  {% set disqus = page.meta.disqus %}
-{% endif %}
-{% if not page.is_homepage and disqus %}
+{% set disqusIdentifier = page and page.meta and page.meta.disqus is string ? page.meta.disqus : disqus %}
+{% if not page.is_homepage and disqusIdentifier %}
   <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
   <div id="disqus_thread"></div>
   <script>
     var disqus_config = function () {
       this.page.url = "{{ page.canonical_url }}";
-      this.page.identifier =
-        "{{ page.canonical_url | replace(config.site_url, "") }}";
+      this.page.identifier = "{{ page.canonical_url | replace(config.site_url, "") }}";
     };
     (function() {
       var d = document, s = d.createElement("script");
-      s.src = "//{{ disqus }}.disqus.com/embed.js";
+      s.src = "//{{ disqusIdentifier }}.disqus.com/embed.js";
       s.setAttribute("data-timestamp", +new Date());
       (d.head || d.body).appendChild(s);
     })();


### PR DESCRIPTION


1.  Renamed `disqus` variable to `disqusIdentifier` for better clarity.
2.  Used ternary operator to set `disqusIdentifier` based on conditions.
3.  Used `disqusIdentifier` in the Disqus script source URL.
4.  Replaced `config.extra.disqus` with `disqusIdentifier` in the Disqus script source URL.
5. Consolidated `if` conditions to check if `disqusIdentifier` is truthy before rendering the Disqus section.